### PR TITLE
Add the `--match` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Consider a `_service` file that includes the following:
   <param name="file">mariadb-image.kiwi</param>
   <param name="regex">%%TAG%%</param>
   <param name="package">mariadb</param>
-  <param name="match">(\d+(\.\d+){0,1})</param>
+  <param name="parse-version">minor</param>
 </service>
 ```
 
@@ -46,12 +46,11 @@ The service in this case would look for the `mariadb` package in the build
 environment, get its version, and try to replace any occurrence of `%%TAG%%`
 in `mariadb-imgae.kiwi` file with the `mariadb` package version.
 
-The `match` parameter is the pattern match that is applied over the package
-version string. The first group matching the regular expression is the string
-used for the ocurrence replacement. In this concrete case the pattern tries to
-match `<MAJOR.MINOR>` version style. So in case `mariadb` version was
-something like `10.3.4_git_r125` only the `10.3` part would be used as the
-replacement string.
+The `parse-version` states to use only up to the minor version part for a given
+versio string. For instance, in this specific case, the service will
+apply the `^(\d+(\.\d+){0,1})` regular expression and use only the first match.
+In case `mariadb` version was `10.3.4~git_r154` only the `10.3` part would be
+used as the replacement string.
 
 This service is mainly designed to work in `buildtime` mode, so it is applied
 inside the build environment just before the start of the build.

--- a/README.md
+++ b/README.md
@@ -38,12 +38,20 @@ Consider a `_service` file that includes the following:
   <param name="file">mariadb-image.kiwi</param>
   <param name="regex">%%TAG%%</param>
   <param name="package">mariadb</param>
+  <param name="match">(\d+(\.\d+){0,1})</param>
 </service>
 ```
 
-The service in this case would look for the `mariadb` in the build environment,
-get the version of the package, and try to replace any occurrence of `%%TAG%%`
+The service in this case would look for the `mariadb` package in the build
+environment, get its version, and try to replace any occurrence of `%%TAG%%`
 in `mariadb-imgae.kiwi` file with the `mariadb` package version.
+
+The `match` parameter is the pattern match that is applied over the package
+version string. The first group matching the regular expression is the string
+used for the ocurrence replacement. In this concrete case the pattern tries to
+match `<MAJOR.MINOR>` version style. So in case `mariadb` version was
+something like `10.3.4_git_r125` only the `10.3` part would be used as the
+replacement string.
 
 This service is mainly designed to work in `buildtime` mode, so it is applied
 inside the build environment just before the start of the build.

--- a/replaceUsingPackageVersion/replace_using_package_version.py
+++ b/replaceUsingPackageVersion/replace_using_package_version.py
@@ -26,6 +26,7 @@ Usage:
     replace_using_package_version.py -h
     replace_using_package_version.py --file=FILE --regex=REGEX --outdir=DIR
         (--package=PACKAGE | --replacement=REPLACEMENT)
+        [--match=REGEX]
 
 Options:
     -h,--help                   : show this help message
@@ -33,7 +34,9 @@ Options:
     --file=FILE                 : file to update
     --package=PACKAGE           : package to check
     --replacement=REPLACEMENT   : replacement string for any match
-    --regex=REGEX               : regular expression for parsing
+    --regex=REGEX               : regular expression for parsing file
+    --match=REGEX               : regular expression for verison
+                                    first match will be used for replacement
 """
 import docopt
 import re
@@ -65,6 +68,8 @@ def main():
 
     if command_args['--package']:
         version = find_package_version(command_args['--package'], rpm_dir)
+        if command_args['--match']:
+            version = find_match_in_version(command_args['--match'], version)
         replacement = version
     else:
         replacement = command_args['--replacement']
@@ -104,6 +109,15 @@ def find_package_version(package, rpm_dir):
     if not str(version):
         raise Exception('Package version not found')
     return str(version)
+
+
+def find_match_in_version(regexpr, version):
+    search = re.search(regexpr, version)
+    if search is None:
+        raise Exception(
+            'No match found for {0} in {1}'.format(regexpr, version))
+    else:
+        return search.group(1)
 
 
 def run_command(command):

--- a/replaceUsingPackageVersion/replace_using_package_version.py
+++ b/replaceUsingPackageVersion/replace_using_package_version.py
@@ -26,7 +26,7 @@ Usage:
     replace_using_package_version.py -h
     replace_using_package_version.py --file=FILE --regex=REGEX --outdir=DIR
         (--package=PACKAGE | --replacement=REPLACEMENT)
-        [--match=REGEX]
+        [--parse-version=DEPTH]
 
 Options:
     -h,--help                   : show this help message
@@ -35,8 +35,9 @@ Options:
     --package=PACKAGE           : package to check
     --replacement=REPLACEMENT   : replacement string for any match
     --regex=REGEX               : regular expression for parsing file
-    --match=REGEX               : regular expression for verison
-                                    first match will be used for replacement
+    --parse-version=DEPTH       : parse the package version string to match
+                                    major.minor.patch format. It can be set
+                                    to 'major', 'minor' or 'patch'.
 """
 import docopt
 import re
@@ -51,6 +52,12 @@ def main():
     """
     # TODO: probably there is a better way to set the repositories path
     rpm_dir = './repos'
+
+    version_regex = {
+        'major': '^(\d+)',
+        'minor': '^(\d+(\.\d+){0,1})',
+        'patch': '^(\d+(\.\d+){0,2})'
+    }
 
     command_args = docopt.docopt(__doc__)
 
@@ -67,9 +74,17 @@ def main():
     ])
 
     if command_args['--package']:
+        parse_version = command_args['--parse-version']
         version = find_package_version(command_args['--package'], rpm_dir)
-        if command_args['--match']:
-            version = find_match_in_version(command_args['--match'], version)
+        if parse_version and parse_version not in version_regex.keys():
+            raise Exception((
+                'Invalid value for this flag. Expected format is: '
+                '--parse-version=[major|minor|patch]'
+            ))
+        elif parse_version:
+            version = find_match_in_version(
+                version_regex[parse_version], version
+            )
         replacement = version
     else:
         replacement = command_args['--replacement']

--- a/replaceUsingPackageVersion/replace_using_package_version.py
+++ b/replaceUsingPackageVersion/replace_using_package_version.py
@@ -114,8 +114,7 @@ def find_package_version(package, rpm_dir):
 def find_match_in_version(regexpr, version):
     search = re.search(regexpr, version)
     if search is None:
-        raise Exception(
-            'No match found for {0} in {1}'.format(regexpr, version))
+        return version
     else:
         return search.group(1)
 

--- a/replace_using_package_version.service
+++ b/replace_using_package_version.service
@@ -14,6 +14,13 @@ It uses python re module syntax</description>
     <description>This is the package whos version will be used as a replacement
 for the regex. It must be included to the build as dependency.</description>
   </parameter>
+  <parameter name="match">
+    <description>This is a regular expression applied to the version of
+    of the package, if present first match is used as the replacement string.
+    If no match the full version string is used as the replacement string.
+    This is mostly used to get only a relevant part of the version (e.g. turn
+    something like 3.2.1~git124basdf to 3.2).</description>
+  </parameter>
   <parameter name="replacement">
     <description>This parameter is an alternative to the package parameter,
 instead to look for a package version it will just use the given string

--- a/replace_using_package_version.service
+++ b/replace_using_package_version.service
@@ -14,16 +14,20 @@ It uses python re module syntax</description>
     <description>This is the package whos version will be used as a replacement
 for the regex. It must be included to the build as dependency.</description>
   </parameter>
-  <parameter name="match">
-    <description>This is a regular expression applied to the version of
-    of the package, if present first match is used as the replacement string.
-    If no match the full version string is used as the replacement string.
-    This is mostly used to get only a relevant part of the version (e.g. turn
-    something like 3.2.1~git124basdf to 3.2).</description>
+  <parameter name="parse-version">
+    <description>Parses the package version string to match the
+major.minor.patch format. Then any found match is used as the replacement
+string. It can be set to three different values: major, minor or patch.
+If set to major only the first numeric value will be used as the
+replacement (e.g. if version is 3.1.3 only 3 will be used). If set to minor
+only the first and seconf numeric values separated by a dot will be used
+(e.g. if version is 3.1~git_r125 only 3.1 will be used). If set to patch
+it will reach up to the first three numeric values separated with a dots.
   </parameter>
   <parameter name="replacement">
     <description>This parameter is an alternative to the package parameter,
 instead to look for a package version it will just use the given string
-for the regex replacement. It is mostly used to debug or test the regex.</description>
+for the regex replacement. It is mostly used to debug or test the
+regex.</description>
   </parameter>
 </service>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 coverage
 docopt
 flake8
-pycodestyle
 pytest
 pytest-cov
 tox

--- a/test/replace_using_package_version_test.py
+++ b/test/replace_using_package_version_test.py
@@ -38,12 +38,8 @@ class TestRegexReplacePackageVersion(object):
         assert match == '0.0'
         match = find_match_in_version('^(\d+(\.\d+){0,1})', '234~rev+af232f')
         assert match == '234'
-        try:
-            match = find_match_in_version(
-                '^(\d+(\.\d+){0,1})', 'as234~rev+af232f'
-            )
-        except Exception as e:
-            assert 'No match found for' in str(e)
+        match = find_match_in_version('^(\d+(\.\d+){0,1})', 'as234~rev+af232f')
+        assert match == 'as234~rev+af232f'
 
     @patch((
         'replaceUsingPackageVersion.'


### PR DESCRIPTION
This new flag is mostly used to match just a portion of the version
of the requested package. This is handy when the package version
includes more information of what we need (.e.g imagine we just
want to use the major version).