### PR TITLE
new patch_update and offset parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Possible `parse-version` values and it returned value in X.Y.Z.N version:
 * `minor`: `^(\d+(\.\d+){0,1})`, returns X.Y
 * `patch`: `^(\d+(\.\d+){0,2})`, returns X.Y.Z
 * `patch_update`: `^(\d+(\.\d+){0,3})`, returns X.Y.Z.N
-* `offset`: `^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)`
+* `offset`: `^(?:\d+(?:\.\d+){0,3})[+-.~](?:git|svn|cvs)(\d+)`
   * returns X.Y.Z.N as it doesn't match
-  * but if you have offset in your version X.Y.Z+git5 it return 5
+  * but if you have offset in your version X.Y.Z+git5 it returns 5
 * `parse-version` is absent or parameter doesn't match, returns X.Y.Z.N
 
 For instance, in this specific case, the service will apply the 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,29 @@ The service in this case would look for the `mariadb` package in the build
 environment, get its version, and try to replace any occurrence of `%%TAG%%`
 in `mariadb-image.kiwi` file with the `mariadb` package version.
 
-The `parse-version` states to use only up to the minor version part for a given
-versio string. For instance, in this specific case, the service will
-apply the `^(\d+(\.\d+){0,1})` regular expression and use only the first match.
+The `parse-version` could be skipped or if parameter's regular expression 
+doesn't match then full package version is returned.
+
+Possible `parse-version` values and it returned value in X.Y.Z.N version:
+
+* `major`: `^(\d+)`, returns X
+* `minor`: `^(\d+(\.\d+){0,1})`, returns X.Y
+* `patch`: `^(\d+(\.\d+){0,2})`, returns X.Y.Z
+* `patch_update`: `^(\d+(\.\d+){0,3})`, returns X.Y.Z.N
+* `offset`: `^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)`
+  * returns X.Y.Z.N as it doesn't match
+  * but if you have offset in your version X.Y.Z+git5 it return 5
+* `parse-version` is absent or parameter doesn't match, returns X.Y.Z.N
+
+For instance, in this specific case, the service will apply the 
+`^(\d+(\.\d+){0,1})` regular expression and use only the first match.
 In case `mariadb` version was `10.3.4~git_r154` only the `10.3` part would be
 used as the replacement string.
+
+You could use this service multiple times in your `_service` file so `offset` 
+parameter could be used in case you need more unique identification. 
+For example %%TAG%%.%%OFFSET%% if you add another service with `regex` "%%OFFSET%%"
+and `parse-version` "offset".
 
 This service is mainly designed to work in `buildtime` mode, so it is applied
 inside the build environment just before the start of the build.

--- a/replaceUsingPackageVersion/replace_using_package_version.py
+++ b/replaceUsingPackageVersion/replace_using_package_version.py
@@ -46,6 +46,14 @@ import os
 import subprocess
 from pkg_resources import parse_version
 
+version_regex = {
+    'major': r'^(\d+)',
+    'minor': r'^(\d+(\.\d+){0,1})',
+    'patch': r'^(\d+(\.\d+){0,2})',
+    'patch_update': r'^(\d+(\.\d+){0,3})',
+    'offset': r'^(?:\d+(?:\.\d+){0,3})[+-.~](?:git|svn|cvs)(\d+)'
+}
+
 
 def main():
     """
@@ -53,14 +61,6 @@ def main():
     """
     # TODO: probably there is a better way to set the repositories path
     rpm_dir = './repos'
-
-    version_regex = {
-        'major': r'^(\d+)',
-        'minor': r'^(\d+(\.\d+){0,1})',
-        'patch': r'^(\d+(\.\d+){0,2})',
-        'patch_update': r'^(\d+(\.\d+){0,3})',
-        'offset': r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)'
-    }
 
     command_args = docopt.docopt(__doc__)
 
@@ -82,7 +82,7 @@ def main():
         if parse_version and parse_version not in version_regex.keys():
             raise Exception((
                 'Invalid value for this flag. Expected format is: '
-                '--parse-version=[major|minor|patch]'
+                '--parse-version=[major|minor|patch|patch_update|offset]'
             ))
         elif parse_version:
             version = find_match_in_version(

--- a/replaceUsingPackageVersion/replace_using_package_version.py
+++ b/replaceUsingPackageVersion/replace_using_package_version.py
@@ -36,8 +36,9 @@ Options:
     --replacement=REPLACEMENT   : replacement string for any match
     --regex=REGEX               : regular expression for parsing file
     --parse-version=DEPTH       : parse the package version string to match
-                                    major.minor.patch format. It can be set
-                                    to 'major', 'minor' or 'patch'.
+                                    major.minor.patch.patch_update format. 
+                                    It can be set to 'major', 'minor', 
+                                    'patch, patch_update and offset.
 """
 import docopt
 import re
@@ -56,7 +57,9 @@ def main():
     version_regex = {
         'major': '^(\d+)',
         'minor': '^(\d+(\.\d+){0,1})',
-        'patch': '^(\d+(\.\d+){0,2})'
+        'patch': '^(\d+(\.\d+){0,2})',
+        'patch_update': '^(\d+(\.\d+){0,3})',
+        'offset': '^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)'
     }
 
     command_args = docopt.docopt(__doc__)

--- a/replaceUsingPackageVersion/replace_using_package_version.py
+++ b/replaceUsingPackageVersion/replace_using_package_version.py
@@ -36,8 +36,8 @@ Options:
     --replacement=REPLACEMENT   : replacement string for any match
     --regex=REGEX               : regular expression for parsing file
     --parse-version=DEPTH       : parse the package version string to match
-                                    major.minor.patch.patch_update format. 
-                                    It can be set to 'major', 'minor', 
+                                    major.minor.patch.patch_update format.
+                                    It can be set to 'major', 'minor',
                                     'patch, patch_update and offset.
 """
 import docopt
@@ -55,11 +55,11 @@ def main():
     rpm_dir = './repos'
 
     version_regex = {
-        'major': '^(\d+)',
-        'minor': '^(\d+(\.\d+){0,1})',
-        'patch': '^(\d+(\.\d+){0,2})',
-        'patch_update': '^(\d+(\.\d+){0,3})',
-        'offset': '^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)'
+        'major': r'^(\d+)',
+        'minor': r'^(\d+(\.\d+){0,1})',
+        'patch': r'^(\d+(\.\d+){0,2})',
+        'patch_update': r'^(\d+(\.\d+){0,3})',
+        'offset': r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)'
     }
 
     command_args = docopt.docopt(__doc__)

--- a/test/replace_using_package_version_test.py
+++ b/test/replace_using_package_version_test.py
@@ -7,7 +7,8 @@ from replaceUsingPackageVersion.replace_using_package_version import (
     find_match_in_version,
     main,
     run_command,
-    init
+    init,
+    version_regex
 )
 
 open_to_patch = '{0}.open'.format(
@@ -32,59 +33,60 @@ class TestRegexReplacePackageVersion(object):
         ))
 
     def test_find_match_in_version(self):
-        match = find_match_in_version(r'^(\d+)', '0.0.1')
+        match = find_match_in_version(version_regex['major'], '0.0.1')
         assert match == '0'
         match = find_match_in_version(
-            r'^(\d+(\.\d+){0,1})',
+            version_regex['minor'],
             '0.0.1~rev+af232f')
         assert match == '0.0'
 
         match = find_match_in_version(
-            r'^(\d+(\.\d+){0,2})',
+            version_regex['patch'],
             '0.0.1~rev+af232f')
         assert match == '0.0.1'
         match = find_match_in_version(
-            r'^(\d+(\.\d+){0,2})',
+            version_regex['patch'],
             '234~rev+af232f')
         assert match == '234'
 
         match = find_match_in_version(
-            r'^(\d+(\.\d+){0,1})', 'as234~rev+af232f')
+            version_regex['minor'], 'as234~rev+af232f')
         assert match == 'as234~rev+af232f'
 
-        match = find_match_in_version(r'^(\d+(\.\d+){0,3})', '234~rev+af232f')
+        match = find_match_in_version(
+            version_regex['patch_update'], '234~rev+af232f')
         assert match == '234'
         match = find_match_in_version(
-            r'^(\d+(\.\d+){0,3})',
+            version_regex['patch_update'],
             '14.2.1.468+g994fd9e0cc')
         assert match == '14.2.1.468'
         match = find_match_in_version(
-            r'^(\d+(\.\d+){0,3})',
+            version_regex['patch_update'],
             '0.0.1~rev+af232f')
         assert match == '0.0.1'
 
         match = find_match_in_version(
-            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            version_regex['offset'],
             '3.14.1+git5.g9265358')
         assert match == '5'
         match = find_match_in_version(
-            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            version_regex['offset'],
             '3.14.1+svn592')
         assert match == '592'
         match = find_match_in_version(
-            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            version_regex['offset'],
             '2.14.1+cvs20130621')
         assert match == '20130621'
         match = find_match_in_version(
-            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            version_regex['offset'],
             '0.0.1~rev+af232f')
         assert match == '0.0.1~rev+af232f'
         match = find_match_in_version(
-            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            version_regex['offset'],
             '234~rev+af232f')
         assert match == '234~rev+af232f'
         match = find_match_in_version(
-            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            version_regex['offset'],
             '14.2.1.468+g994fd9e0cc')
         assert match == '14.2.1.468+g994fd9e0cc'
 
@@ -236,7 +238,7 @@ class TestRegexReplacePackageVersion(object):
             'file', 'outdir/file', 'regex', '0.0'
         )
         mock_match_version.assert_called_once_with(
-            r'^(\d+(\.\d+){0,1})', '0.0.1'
+            version_regex['minor'], '0.0.1'
         )
 
     @patch((

--- a/test/replace_using_package_version_test.py
+++ b/test/replace_using_package_version_test.py
@@ -32,43 +32,60 @@ class TestRegexReplacePackageVersion(object):
         ))
 
     def test_find_match_in_version(self):
-        match = find_match_in_version('^(\d+)', '0.0.1')
+        match = find_match_in_version(r'^(\d+)', '0.0.1')
         assert match == '0'
-        match = find_match_in_version('^(\d+(\.\d+){0,1})', '0.0.1~rev+af232f')
+        match = find_match_in_version(
+            r'^(\d+(\.\d+){0,1})',
+            '0.0.1~rev+af232f')
         assert match == '0.0'
-        
-        match = find_match_in_version('^(\d+(\.\d+){0,2})', '0.0.1~rev+af232f')
+
+        match = find_match_in_version(
+            r'^(\d+(\.\d+){0,2})',
+            '0.0.1~rev+af232f')
         assert match == '0.0.1'
-        match = find_match_in_version('^(\d+(\.\d+){0,2})', '234~rev+af232f')
+        match = find_match_in_version(
+            r'^(\d+(\.\d+){0,2})',
+            '234~rev+af232f')
         assert match == '234'
-        
-        match = find_match_in_version('^(\d+(\.\d+){0,1})', 'as234~rev+af232f')
+
+        match = find_match_in_version(
+            r'^(\d+(\.\d+){0,1})', 'as234~rev+af232f')
         assert match == 'as234~rev+af232f'
-        
-        match = find_match_in_version('^(\d+(\.\d+){0,3})', '234~rev+af232f')
+
+        match = find_match_in_version(r'^(\d+(\.\d+){0,3})', '234~rev+af232f')
         assert match == '234'
-        match = find_match_in_version('^(\d+(\.\d+){0,3})', '14.2.1.468+g994fd9e0cc')
+        match = find_match_in_version(
+            r'^(\d+(\.\d+){0,3})',
+            '14.2.1.468+g994fd9e0cc')
         assert match == '14.2.1.468'
-        match = find_match_in_version('^(\d+(\.\d+){0,3})', '0.0.1~rev+af232f')
+        match = find_match_in_version(
+            r'^(\d+(\.\d+){0,3})',
+            '0.0.1~rev+af232f')
         assert match == '0.0.1'
-        
-        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
-                '3.14.1+git5.g9265358')
+
+        match = find_match_in_version(
+            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            '3.14.1+git5.g9265358')
         assert match == '5'
-        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
-                '3.14.1+svn592')
+        match = find_match_in_version(
+            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            '3.14.1+svn592')
         assert match == '592'
-        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
-                '2.14.1+cvs20130621')
+        match = find_match_in_version(
+            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            '2.14.1+cvs20130621')
         assert match == '20130621'
-        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
-                '0.0.1~rev+af232f')
+        match = find_match_in_version(
+            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            '0.0.1~rev+af232f')
         assert match == '0.0.1~rev+af232f'
-        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
-                '234~rev+af232f')
+        match = find_match_in_version(
+            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            '234~rev+af232f')
         assert match == '234~rev+af232f'
-        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
-                '14.2.1.468+g994fd9e0cc')
+        match = find_match_in_version(
+            r'^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)',
+            '14.2.1.468+g994fd9e0cc')
         assert match == '14.2.1.468+g994fd9e0cc'
 
     @patch((
@@ -219,7 +236,7 @@ class TestRegexReplacePackageVersion(object):
             'file', 'outdir/file', 'regex', '0.0'
         )
         mock_match_version.assert_called_once_with(
-            '^(\d+(\.\d+){0,1})', '0.0.1'
+            r'^(\d+(\.\d+){0,1})', '0.0.1'
         )
 
     @patch((

--- a/test/replace_using_package_version_test.py
+++ b/test/replace_using_package_version_test.py
@@ -36,12 +36,40 @@ class TestRegexReplacePackageVersion(object):
         assert match == '0'
         match = find_match_in_version('^(\d+(\.\d+){0,1})', '0.0.1~rev+af232f')
         assert match == '0.0'
+        
         match = find_match_in_version('^(\d+(\.\d+){0,2})', '0.0.1~rev+af232f')
         assert match == '0.0.1'
         match = find_match_in_version('^(\d+(\.\d+){0,2})', '234~rev+af232f')
         assert match == '234'
+        
         match = find_match_in_version('^(\d+(\.\d+){0,1})', 'as234~rev+af232f')
         assert match == 'as234~rev+af232f'
+        
+        match = find_match_in_version('^(\d+(\.\d+){0,3})', '234~rev+af232f')
+        assert match == '234'
+        match = find_match_in_version('^(\d+(\.\d+){0,3})', '14.2.1.468+g994fd9e0cc')
+        assert match == '14.2.1.468'
+        match = find_match_in_version('^(\d+(\.\d+){0,3})', '0.0.1~rev+af232f')
+        assert match == '0.0.1'
+        
+        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
+                '3.14.1+git5.g9265358')
+        assert match == '5'
+        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
+                '3.14.1+svn592')
+        assert match == '592'
+        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
+                '2.14.1+cvs20130621')
+        assert match == '20130621'
+        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
+                '0.0.1~rev+af232f')
+        assert match == '0.0.1~rev+af232f'
+        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
+                '234~rev+af232f')
+        assert match == '234~rev+af232f'
+        match = find_match_in_version('^(?:\d+(?:\.\d+){0,2})\+(?:git|svn|cvs)(\d+)', 
+                '14.2.1.468+g994fd9e0cc')
+        assert match == '14.2.1.468+g994fd9e0cc'
 
     @patch((
         'replaceUsingPackageVersion.'


### PR DESCRIPTION
Some of the packages could use source control offset to better identify version for their packages.
This could look like as "3.14.1+git5.g9265358", it is described in [Package naming guidelines](https://en.opensuse.org/openSUSE:Package_naming_guidelines) for openSUSE.

Other packages could use fourth digit as identification, that could be anything, for example "ceph" package uses that for the same source code offset (maybe incorrectly but possibility is there).

This patch add those 2 new parameters. They could be used as unique tags for the containers as "+" character is not allowed in the tag name for the docker container.