### PR TITLE
Ignore stderr on successful command executions

### DIFF
--- a/integration_tests/test_version_extraction.py
+++ b/integration_tests/test_version_extraction.py
@@ -16,6 +16,8 @@ RUN echo $'This is a testfile with some replacements like %%MINOR%%\n\
 %NEVR%\n\
 and a footer?' > {TESTFILE}
 
+# remove the signkeys to mimic the state in OBS workers
+RUN rpm -qa|grep '^gpg-pubkey'|xargs rpm -e
 RUN mkdir -p /.build-srcdir/repos/ && mv $(find /var/cache/zypp/ -name 'apache*') /.build-srcdir/repos/
 
 RUN mkdir /.build/ && echo $'RECIPEFILE="Dockerfile"\n\

--- a/replace_using_package_version/replace_using_package_version.py
+++ b/replace_using_package_version/replace_using_package_version.py
@@ -189,7 +189,7 @@ def find_match_in_version(regexpr, version):
 
 
 def run_command(command: List[str]) -> str:
-    return subprocess.check_output(command, stderr=subprocess.STDOUT).decode()
+    return subprocess.check_output(command).decode()
 
 
 def get_pkg_name_from_rpm(rpm_file):

--- a/test/replace_using_package_version_test.py
+++ b/test/replace_using_package_version_test.py
@@ -90,22 +90,16 @@ class TestRegexReplacePackageVersion(object):
             '14.2.1.468+g994fd9e0cc')
         assert match == '14.2.1.468+g994fd9e0cc'
 
-    @patch((
-        'replace_using_package_version.'
-        'replace_using_package_version.run_command'
-    ))
+    @patch('subprocess.check_output')
     def test_find_package_version(self, mock_run):
-        mock_run.return_value = '2.3.1'
+        mock_run.return_value = b'2.3.1'
         assert find_package_version('package', '/foo') == '2.3.1'
         mock_run.called_once_with([
             'rpm', '-q', '--queryformat',
             '%{NAME}', 'package.rpm'
         ])
 
-    @patch((
-        'replace_using_package_version.'
-        'replace_using_package_version.run_command'
-    ))
+    @patch('subprocess.check_output')
     @patch('os.walk')
     def test_find_package_version_rpm_not_installed(self, mock_walk, mock_run):
         mock_walk.return_value = [
@@ -113,7 +107,7 @@ class TestRegexReplacePackageVersion(object):
             ('/foo/bar', [], ['spam', 'package.rpm']),
             ('/foo/zez', [], ['package.rpm', 'somefile'])
         ]
-        outputs = ['2.3.1', 'package', '2.2.4', 'package']
+        outputs = [b'2.3.1', b'package', b'2.2.4', b'package']
 
         def cmd_output(command):
             if '-q' in command:
@@ -133,10 +127,7 @@ class TestRegexReplacePackageVersion(object):
             ]),
         ])
 
-    @patch((
-        'replace_using_package_version.'
-        'replace_using_package_version.run_command'
-    ))
+    @patch('subprocess.check_output')
     @patch('os.walk')
     def test_find_package_version_not_found(self, mock_walk, mock_run):
         mock_walk.return_value = [
@@ -144,7 +135,7 @@ class TestRegexReplacePackageVersion(object):
             ('/foo/bar', [], ['spam', 'package.rpm']),
             ('/foo/zez', [], ['package.rpm', 'somefile'])
         ]
-        outputs = ['another_non_matching_name', 'not_matching_name']
+        outputs = [b'another_non_matching_name', b'not_matching_name']
 
         def cmd_output(command):
             if '-q' in command:


### PR DESCRIPTION
This fixes a regression from 43e56dd1. On success, the command output should only include the stdout, otherwise we get the normalized output of rpm queries polluted with potential warning messages.

In case of error python's subprocess will already rise an Exception with stdout, sdterr and return code.

Signed-off-by: David Cassany <dcassany@suse.com>