### PR TITLE
Add support for replacing package versions by capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ environment, get its version, and try to replace any occurrence of `%%TAG%%`
 in the `mariadb-setup.sh` file with the `mariadb` package version.
 
 In case the `mariadb` rpm package is not found within the build environment
-it will also try to fecth the version from a `mariadb.obsinfo` file if any.
+it will also try to fetch the version from a `mariadb.obsinfo` file if any.
+
+The service will look for packages providing `mariadb` if both obtaining the
+version from the file and from `mariadb.obsinfo` fails. If such a package is
+found, then its version is used.
+
 The service fails if no version can be determined.
 
 `*.obsinfo` files are metadata files produced by the `obs_scm` service, which

--- a/integration_tests/test_version_extraction.py
+++ b/integration_tests/test_version_extraction.py
@@ -210,3 +210,16 @@ def test_version_replacement_from_invalid_python_version(
         auto_container_per_test.connection.file(TESTFILE).content_string.splitlines()[1]
         == hello_world_ver
     )
+
+
+def test_version_replacement_from_provides(auto_container_per_test: ContainerData) -> None:
+    auto_container_per_test.connection.check_output(f"replace_using_package_version --file {TESTFILE} --outdir /opt/ --regex='%NEVR%' --package='httpd'")
+
+    apache2_ver = auto_container_per_test.connection.check_output(
+        "rpm -q --qf '%{version}' /.build-srcdir/repos/apache*rpm",
+    ).strip()
+
+    assert (
+        auto_container_per_test.connection.file(TESTFILE).content_string.splitlines()[1]
+        == apache2_ver
+    )

--- a/replace_using_package_version/replace_using_package_version.py
+++ b/replace_using_package_version/replace_using_package_version.py
@@ -171,6 +171,9 @@ def find_package_version(package, rpm_dir):
         version = find_package_version_in_obsinfo('.', package)
 
     if version is None:
+        version = find_package_version_by_capability(rpm_dir, package)
+
+    if version is None:
         raise Exception(f'Package {package} version not found')
     return str(version)
 
@@ -187,6 +190,26 @@ def find_package_version_in_local_repos(repo_path, package):
                 rpm_ver = get_pkg_version_from_rpm(rpm_file)
                 if version is None or labelCompare(rpm_ver, version) >= 0:
                     version = rpm_ver
+    return version
+
+
+def find_package_version_by_capability(
+    repo_path: str, capability: str
+) -> Optional[str]:
+    """Find the highest rpm package version of all packages in `repo_path` that
+    have a rpm provides containing the string `capability`.
+
+    """
+    version = None
+    for root, _, files in os.walk(repo_path):
+        packages = [f for f in files if f.endswith('rpm')]
+        for pkg in packages:
+            rpm_file = os.path.join(root, pkg)
+            for provide in get_pkg_provides_from_rpm(rpm_file):
+                if capability in provide:
+                    rpm_ver = get_pkg_version_from_rpm(rpm_file)
+                    if version is None or labelCompare(rpm_ver, version) >= 0:
+                        version = rpm_ver
     return version
 
 
@@ -234,6 +257,13 @@ def get_pkg_version_from_rpm(rpm_file: str) -> str:
         'rpm', '-qp', '--queryformat', '%{VERSION}', rpm_file
     ]
     return run_command(command)
+
+
+def get_pkg_provides_from_rpm(rpm_file: str) -> List[str]:
+    res = subprocess.run(['rpm', '-qP', rpm_file], stdout=subprocess.PIPE)
+    if res.returncode == 0:
+        return res.stdout.decode().strip().splitlines()
+    return []
 
 
 def get_pkg_version(package: str) -> str:


### PR DESCRIPTION
The service would so far only find packages by their name. Now it will recursively search through all packages and consider also their provides if it failed to find the package by name.

This fixes https://github.com/openSUSE/obs-service-replace_using_package_version/issues/6